### PR TITLE
Fix braces issue  JSON extract EXIF

### DIFF
--- a/src/extractMetadata.ts
+++ b/src/extractMetadata.ts
@@ -9,5 +9,13 @@ export const extractMetadata = async (image: Buffer): Promise<Partial<IRawMetada
     const img = new Image()
     await img.load(image)
     const exif = img.exif?.toString('utf-8') ?? '{}'
-    return JSON.parse(exif.substring(exif.indexOf('{'), exif.lastIndexOf('}') + 1) ?? '{}') as IRawMetadata
+    var bracesCount = exif.match(/{/g).length
+
+    var index = 0
+
+    for (let i = 0; i < bracesCount; i++) {
+        index = exif.indexOf('{', index + 1)
+    }
+    
+    return JSON.parse(exif.substring(index, exif.lastIndexOf('}') + 1) ?? '{}') as IRawMetadata
 }


### PR DESCRIPTION
This is an example were it is not returning the object properly.
With this error:
SyntaxError: Unexpected token ☺ in JSON at position 1

and this result on "const exif":
II☺AW{☺▬{"sticker-pack-id":"com.snowcorp.stickerly.android.stickercontentprovider f2c83f90-25c6-4b45-9866-1f6bd657616f","sticker-pack-name":"stickerman","sticker-pack-publisher":"Sticker.ly * dudaxd1212","android-app-store-link":"https:\/\/play.google.com\/store\/apps\/details?id=com.snowcorp.stickerly.android","ios-app-store-link":"https:\/\/itunes.apple.com\/app\/id1458740001?mt=8"}

So I made this correction that fixies this issue and gets the rigth start braces.